### PR TITLE
More inclusive PHP requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "SilverStripe integration with Intercom.io",
     "type": "silverstripe-module",
     "require": {
-        "php": ">5.4.0",
+        "php": ">=5.4.0",
         "silverstripe/framework": "^3.1",
         "intercom/intercom-php": "^1.3"
     },


### PR DESCRIPTION
When `config.platform.php` is set to `5.4` in your `composer.json` file, installation fails, because `5.4.0 > 5.4 === false`