### PR TITLE
Declare classes in global namespace

### DIFF
--- a/code/RequestFilter.php
+++ b/code/RequestFilter.php
@@ -2,6 +2,11 @@
 
 namespace Sminnee\SilverStripeIntercom;
 
+use SS_HTTPRequest;
+use SS_HTTPResponse;
+use Session;
+use DataModel;
+
 class RequestFilter implements \RequestFilter
 {
 	/**
@@ -14,16 +19,16 @@ class RequestFilter implements \RequestFilter
 	/**
 	 * Adds Intercom script tags just before the body
 	 */
-	public function postRequest(SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model) {
+	public function postRequest(SS_HTTPRequest $request, SS_HTTPResponse $response, DataModel $model) {		
 		$mime = $response->getHeader('Content-Type');
 		if(!$mime || strpos($mime, 'text/html') !== false) {
-			$intercomScriptTags = (new intercomScriptTags())->forTemplate();
+			$intercomScriptTags = (new IntercomScriptTags())->forTemplate();
 
 			if($intercomScriptTags) {
 				$content = $response->getBody();
 				$content = preg_replace("/(<\/body[^>]*>)/i", $intercomScriptTags . "\\1", $content);
 				$response->setBody($content);
-			}
+			}			
 		}
 	}
 }


### PR DESCRIPTION
In strict mode, type hints were throwing errors (Sminnee\SilverStripeIntercom\SS_HTTPRequest doesn't exist) Also use proper capitalisation for IntercomScriptTags for consistency